### PR TITLE
Move build status to header of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bwoken
+# Bwoken ![build status](https://secure.travis-ci.org/bendyworks/bwoken.png?branch=master)
 
-Runs your UIAutomation tests from the command line for both iPhone and iPad. ![build status](https://secure.travis-ci.org/bendyworks/bwoken.png?branch=master)
+Runs your UIAutomation tests from the command line for both iPhone and iPad.
 
 Supports coffeescript.
 


### PR DESCRIPTION
Seems like a more popular style to have the build status either in the header, or in its own `Build Status` section.
