### PR TITLE
Custom app scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Make sure bwoken is <a href="#installation">properly installed</a>. Then, build 
 <pre><code># will build and run all of your tests
 $ rake
 
+# will run against specified app scheme:
+$ rake test[CustomScheme]
+
 # will run one file, relative to integration/coffeescript (note: no file extension)
 $ RUN=iphone/focused_test rake
 </code></pre>

--- a/lib/bwoken/build.rb
+++ b/lib/bwoken/build.rb
@@ -4,8 +4,12 @@ require 'bwoken/device'
 module Bwoken
   class Build
 
+    def initialize(app_name=nil)
+      @app_name = app_name || Bwoken.app_name
+    end
+
     def app_dir
-      File.join(configuration_build_dir, "#{Bwoken.app_name}.app")
+      File.join(configuration_build_dir, "#@app_name.app")
     end
 
     def build_path
@@ -13,7 +17,7 @@ module Bwoken
     end
 
     def scheme
-      Bwoken.app_name
+      @app_name
     end
 
     def configuration

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -15,6 +15,7 @@ module Bwoken
     class << self
 
       def run_all device_family, app_name=nil
+        Simulator.app_name      = app_name
         Simulator.device_family = device_family
 
         test_files(device_family).each do |javascript|
@@ -23,6 +24,7 @@ module Bwoken
       end
 
       def run_one feature_name, device_family, app_name=nil
+        Simulator.app_name      = app_name
         Simulator.device_family = device_family
         run File.join(Bwoken.test_suite_path, device_family, "#{feature_name}.js"), app_name
       end

--- a/lib/bwoken/simulator.rb
+++ b/lib/bwoken/simulator.rb
@@ -2,12 +2,16 @@ module Bwoken
   class Simulator
 
     def self.plist_buddy; '/usr/libexec/PlistBuddy'; end
-    def self.plist_file; "#{Bwoken::Build.new.app_dir}/Info.plist"; end
+    def self.plist_file; "#{Bwoken::Build.new(@@app_name).app_dir}/Info.plist"; end
 
     def self.device_family= device_family
       update_device_family_in_plist :delete_array
       update_device_family_in_plist :add_array
       update_device_family_in_plist :add_scalar, device_family
+    end
+
+    def self.app_name= app_name
+      @@app_name = app_name
     end
 
     def self.update_device_family_in_plist action, args = nil

--- a/lib/bwoken/tasks/bwoken.rake
+++ b/lib/bwoken/tasks/bwoken.rake
@@ -64,8 +64,8 @@ CLOBBER.include('integration/tmp')
 
 
 desc 'Compile the workspace'
-task :compile do
-  exit_status = Bwoken::Build.new.compile
+task :compile, :app_name do |t, args|
+  exit_status = Bwoken::Build.new(args[:app_name]).compile
   raise unless exit_status == 0
 end
 
@@ -75,27 +75,29 @@ device_families = %w(iphone ipad)
 device_families.each do |device_family|
 
   namespace device_family do
-    task :test => [RESULTS_DIR, :coffeescript] do
+    task :test, [:app_name] => [RESULTS_DIR, :coffeescript] do |t, args|
       if ENV['RUN']
-        Bwoken::Script.run_one ENV['RUN'], device_family
+        Bwoken::Script.run_one ENV['RUN'], device_family, args[:app_name]
       else
-        Bwoken::Script.run_all device_family
+        Bwoken::Script.run_all device_family, args[:app_name]
       end
     end
   end
 
   desc "Run tests for #{device_family}"
-  task device_family => "#{device_family}:test"
+  task device_family, :app_name do |t, args|
+    task("#{device_family}:test").invoke(args[:app_name])
+  end
 
 end
 
 desc 'Run all tests without compiling first'
-task :test do
+task :test, :app_name do |t, args|
   if ENV['FAMILY']
-    Rake::Task[ENV['FAMILY']].invoke
+    Rake::Task[ENV['FAMILY']].invoke(args[:app_name])
   else
     device_families.each do |device_family|
-      Rake::Task[device_family].invoke
+      Rake::Task[device_family].invoke(args[:app_name])
     end
   end
 end

--- a/spec/lib/bwoken/build_spec.rb
+++ b/spec/lib/bwoken/build_spec.rb
@@ -5,13 +5,27 @@ require 'stringio'
 require 'bwoken/build'
 
 describe Bwoken::Build do
+  before do
+    Bwoken.stub(:app_name => "FakeProject")
+  end
 
   describe '.app_dir', :stub_proj_path do
-    it "returns the app's name with the .app suffix" do
+    before do
       stub_proj_path
       subject.stub(:configuration_build_dir => "#{proj_path}/build/the_sdk")
-      Bwoken.stub(:app_name => "FakeProject")
-      subject.app_dir.should == "#{proj_path}/build/the_sdk/FakeProject.app"
+    end
+
+    context 'with custom app name' do
+      subject { described_class.new('foo') }
+      it "returns the app's name with the .app suffix" do
+        subject.app_dir.should == "#{proj_path}/build/the_sdk/foo.app"
+      end
+    end
+
+    context 'without custom app name' do
+      it "returns the app's name with the .app suffix" do
+        subject.app_dir.should == "#{proj_path}/build/the_sdk/FakeProject.app"
+      end
     end
   end
 

--- a/spec/lib/bwoken/script_spec.rb
+++ b/spec/lib/bwoken/script_spec.rb
@@ -12,14 +12,25 @@ describe Bwoken::Script do
   describe '.run_all' do
     it 'sets the device_family once' do
       Bwoken::Simulator.should_receive(:device_family=).with('foo').once
+      Bwoken::Simulator.stub(:app_name=)
       Bwoken::Script.stub(:run)
       Bwoken::Script.stub(:test_files => %w(a b))
       Bwoken.stub(:test_suite_path)
       Bwoken::Script.run_all 'foo'
     end
 
+    it 'sets the app_name once' do
+      Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Simulator.should_receive(:app_name=).with('bar').once
+      Bwoken::Script.stub(:run)
+      Bwoken::Script.stub(:test_files => %w(a b))
+      Bwoken.stub(:test_suite_path)
+      Bwoken::Script.run_all 'foo', 'bar'
+    end
+
     it "runs all scripts in the device_family's path with default target" do
       Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Simulator.stub(:app_name=)
       Bwoken::Script.stub(:run)
       Bwoken.stub(:test_suite_path)
       Bwoken::Script.stub(:test_files => %w(a b))
@@ -30,6 +41,7 @@ describe Bwoken::Script do
 
     it "runs all scripts in the device_family's path with custom target" do
       Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Simulator.stub(:app_name=)
       Bwoken::Script.stub(:run)
       Bwoken.stub(:test_suite_path)
       Bwoken::Script.stub(:test_files => %w(a b))
@@ -44,13 +56,23 @@ describe Bwoken::Script do
     let(:feature) { 'foo' }
     it 'sets the simulator based on passed in device' do
       Bwoken::Simulator.should_receive(:device_family=).with('ipad').once
+      Bwoken::Simulator.stub(:app_name=)
       Bwoken.stub(:test_suite_path => 'suite')
       Bwoken::Script.stub(:run)
       Bwoken::Script.run_one feature, 'ipad'
     end
 
+    it 'sets app name' do
+      Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Simulator.should_receive(:app_name=).with('foo').once
+      Bwoken.stub(:test_suite_path => 'suite')
+      Bwoken::Script.stub(:run)
+      Bwoken::Script.run_one feature, 'ipad', 'foo'
+    end
+
     it 'runs the one script with default target' do
       Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Simulator.stub(:app_name=)
       Bwoken.stub(:test_suite_path => 'suite')
       Bwoken::Script.should_receive(:run).with("suite/ipad/#{feature}.js", nil).once
       Bwoken::Script.run_one feature, 'ipad'
@@ -58,6 +80,7 @@ describe Bwoken::Script do
 
     it 'runs the one script with custom target' do
       Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Simulator.stub(:app_name=)
       Bwoken.stub(:test_suite_path => 'suite')
       Bwoken::Script.should_receive(:run).with("suite/ipad/#{feature}.js", 'bar').once
       Bwoken::Script.run_one feature, 'ipad', 'bar'

--- a/spec/lib/bwoken/script_spec.rb
+++ b/spec/lib/bwoken/script_spec.rb
@@ -18,14 +18,24 @@ describe Bwoken::Script do
       Bwoken::Script.run_all 'foo'
     end
 
-    it "runs all scripts in the device_family's path" do
+    it "runs all scripts in the device_family's path with default target" do
       Bwoken::Simulator.stub(:device_family=)
       Bwoken::Script.stub(:run)
       Bwoken.stub(:test_suite_path)
       Bwoken::Script.stub(:test_files => %w(a b))
-      Bwoken::Script.should_receive(:run).with('a').once.ordered
-      Bwoken::Script.should_receive(:run).with('b').once.ordered
+      Bwoken::Script.should_receive(:run).with('a', nil).once.ordered
+      Bwoken::Script.should_receive(:run).with('b', nil).once.ordered
       Bwoken::Script.run_all 'foo'
+    end
+
+    it "runs all scripts in the device_family's path with custom target" do
+      Bwoken::Simulator.stub(:device_family=)
+      Bwoken::Script.stub(:run)
+      Bwoken.stub(:test_suite_path)
+      Bwoken::Script.stub(:test_files => %w(a b))
+      Bwoken::Script.should_receive(:run).with('a', 'bar').once.ordered
+      Bwoken::Script.should_receive(:run).with('b', 'bar').once.ordered
+      Bwoken::Script.run_all 'foo', 'bar'
     end
 
   end
@@ -39,12 +49,20 @@ describe Bwoken::Script do
       Bwoken::Script.run_one feature, 'ipad'
     end
 
-    it 'runs the one script' do
+    it 'runs the one script with default target' do
       Bwoken::Simulator.stub(:device_family=)
       Bwoken.stub(:test_suite_path => 'suite')
-      Bwoken::Script.should_receive(:run).with("suite/ipad/#{feature}.js").once
+      Bwoken::Script.should_receive(:run).with("suite/ipad/#{feature}.js", nil).once
       Bwoken::Script.run_one feature, 'ipad'
     end
+
+    it 'runs the one script with custom target' do
+      Bwoken::Simulator.stub(:device_family=)
+      Bwoken.stub(:test_suite_path => 'suite')
+      Bwoken::Script.should_receive(:run).with("suite/ipad/#{feature}.js", 'bar').once
+      Bwoken::Script.run_one feature, 'ipad', 'bar'
+    end
+
   end
 
   describe '.test_files' do
@@ -59,25 +77,27 @@ describe Bwoken::Script do
   describe '.run' do
 
     it 'instantiates a script object' do
-      script_double = double('script', :path= => nil, :run => nil)
+      script_double = double('script', :path= => nil, :app_name= => nil, :run => nil)
       Bwoken::Script.should_receive(:new).and_return(script_double)
-      Bwoken::Script.run ''
+      Bwoken::Script.run '', nil
     end
 
-    it 'sets the path' do
+    it 'sets the path and app_name' do
       script_double = double('script', :run => nil)
       script_double.should_receive(:path=)
+      script_double.should_receive(:app_name=)
       Bwoken::Script.stub(:new => script_double)
-      Bwoken::Script.run ''
+      Bwoken::Script.run '', ''
     end
 
     it 'calls run after configuring the path' do
       script_double = double('script', :run => nil)
       script_double.should_receive(:path=).once.ordered
+      script_double.should_receive(:app_name=).once.ordered
       script_double.should_receive(:run).once.ordered
 
       Bwoken::Script.should_receive(:new).and_return(script_double)
-      Bwoken::Script.run ''
+      Bwoken::Script.run '', nil
     end
   end
 
@@ -135,7 +155,7 @@ describe Bwoken::Script do
 
     shared_examples 'returns the correct unix_instruments command' do
       it 'matches the regexp' do
-        subject.cmd.should match regexp
+        subject.cmd(nil).should match regexp
       end
     end
 


### PR DESCRIPTION
Right now scheme for `xcodebuild` and app name for `instruments` are calculated from workspace file name. I think it would be useful to provide ability to change this behaviour. For example, I'm using special target/scheme for `UIAutomation` tests with networking stubs.

I have added argument `:app_name` for  `rake` tasks `:compile` and `:test`(including device specific tests). This :argument is optional and can be omitted. 
