### PR TITLE
Make bwoken more configurable and resilient to spaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bwoken (2.0.0.beta.1)
+    bwoken (2.0.0.beta.2)
       coffee-script-source
       colorful
       execjs

--- a/README.md
+++ b/README.md
@@ -80,15 +80,17 @@ Here's a list of all the switches that bwoken takes for the `test` command:
 <pre><code>
 $ bwoken test -h
 [...]
-        --simulator       Use simulator, even when an iDevice is connected
-        --family          Test only one device type, either ipad or iphone. Default is to test on both
-        --scheme          Specify a custom scheme
-        --formatter       Specify a custom formatter (e.g., --formatter=passthru)
-        --focus           Specify particular tests to run
-        --clobber         Remove any generated file
-        --skip-build      Do not build the iOS binary
-        --verbose         Be verbose
-    -h, --help            Display this help message.
+        --simulator             Use simulator, even when an iDevice is connected
+        --family                Test only one device type, either ipad or iphone. Default is to test on both
+        --scheme                Specify a custom scheme
+        --product-name          Specify a custom product name (e.g. --product-name="My Product"). Default is the name of of the xcodeproj file
+        --integration-path      Specify a custom directory to store your test scripts in (e.g. --integration-path=uiautomation/path/dir). Note that this folder still expects the same directory structure as the one create by `bwoken init`.
+        --formatter             Specify a custom formatter (e.g., --formatter=passthru)
+        --focus                 Specify particular tests to run
+        --clobber               Remove any generated file
+        --skip-build            Do not build the iOS binary
+        --verbose               Be verbose
+    -h, --help                  Display this help message.
 </code></pre>
 
 ## In Your Code

--- a/bin/unix_instruments.sh
+++ b/bin/unix_instruments.sh
@@ -47,11 +47,11 @@ run_instruments() {
   # to make this cleaner?
 
   output=$(mktemp -t unix-instruments)
-  instruments "$@" &> /dev/ttyvf & pid_instruments=$!
+  instruments "$@" &> /dev/ttyuf & pid_instruments=$!
 
   # Cat the instruments output to tee which outputs to stdout and saves to
   # $output at the same time
-  cat < /dev/ptyvf | tee $output
+  cat < /dev/ptyuf | tee $output
 
   # Clear the process id we saved when forking instruments so the cleanup
   # function called on exit knows it doesn't have to kill anything

--- a/bin/unix_instruments.sh
+++ b/bin/unix_instruments.sh
@@ -47,7 +47,7 @@ run_instruments() {
   # to make this cleaner?
 
   output=$(mktemp -t unix-instruments)
-  instruments $@ &> /dev/ttyvf & pid_instruments=$!
+  instruments "$@" &> /dev/ttyvf & pid_instruments=$!
 
   # Cat the instruments output to tee which outputs to stdout and saves to
   # $output at the same time
@@ -87,5 +87,5 @@ function cleanup_instruments() {
 if [[ $1 == "----test" ]]; then
   get_error_status
 else
-  run_instruments $@
+  run_instruments "$@"
 fi

--- a/bwoken.gemspec
+++ b/bwoken.gemspec
@@ -3,12 +3,12 @@ require File.expand_path('../lib/bwoken/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = 'bwoken'
-  gem.version       = Bwoken::VERSION
+  gem.version       = '2.0.0.beta.2' # Bwoken::VERSION
   gem.description   = %q{iOS UIAutomation Test Runner}
   gem.summary       = %q{Runs your UIAutomation tests from the command line for both iPhone and iPad; supports coffeescript}
 
-  gem.authors       = ['Brad Grzesiak', 'Jaymes Waters']
-  gem.email         = ['brad@bendyworks.com', 'jaymes@bendyworks.com']
+  gem.authors       = ['Brad Grzesiak', 'Jaymes Waters', 'Alec Gorge']
+  gem.email         = ['brad@bendyworks.com', 'jaymes@bendyworks.com', 'alecgorge@gmail.com']
   gem.homepage      = 'https://bendyworks.github.com/bwoken'
 
   gem.files        = Dir['LICENSE', 'README.md', 'bin/**/*', 'lib/**/*']

--- a/bwoken.gemspec
+++ b/bwoken.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/bwoken/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = 'bwoken'
-  gem.version       = '2.0.0.beta.2' # Bwoken::VERSION
+  gem.version       = Bwoken::VERSION
   gem.description   = %q{iOS UIAutomation Test Runner}
   gem.summary       = %q{Runs your UIAutomation tests from the command line for both iPhone and iPad; supports coffeescript}
 

--- a/lib/bwoken.rb
+++ b/lib/bwoken.rb
@@ -5,7 +5,11 @@ module Bwoken
     DEVICE_FAMILIES = %w(iphone ipad)
 
     def path
-      File.join(project_path, 'integration')
+      File.join(project_path, @integration_path)
+    end
+
+    def integration_path= new_integration_path
+      @integration_path = new_integration_path
     end
 
     def tmp_path
@@ -13,7 +17,15 @@ module Bwoken
     end
 
     def app_name
-      File.basename(File.basename(workspace_or_project, '.xcodeproj'), '.xcworkspace')
+      if @name && @name != ''
+        @name
+      else
+        File.basename(File.basename(workspace_or_project, '.xcodeproj'), '.xcworkspace')
+      end
+    end
+
+    def app_name= name
+      @name = name
     end
 
     def project_path

--- a/lib/bwoken/cli.rb
+++ b/lib/bwoken/cli.rb
@@ -14,7 +14,8 @@ opts = Slop.parse :help => true do
 
   command 'init' do
     banner Bwoken::CLI::Init.help_banner
-
+    on :'integration-path=', 'Specify a custom directory to store your test scripts in (e.g. --integration-path=uiautomation/path/dir). Default: integration. If you use the non-default value here, you will need to always run bwoken with the `--integration-path=your/integration/dir` option.', :efault => 'integration'
+    
     run { ran_command = 'init' }
   end
 
@@ -26,6 +27,8 @@ opts = Slop.parse :help => true do
     on :family=, 'Test only one device type, either ipad or iphone. Default is to test on both',
       :match => /\A(?:ipad|iphone|all)\Z/i, :default => 'all'
     on :scheme=, 'Specify a custom scheme'
+    on :'product-name=', 'Specify a custom product name (e.g. --product-name="My Product"). Default is the name of of the xcodeproj file', :default => ''
+    on :'integration-path=', 'Specify a custom directory to store your test scripts in (e.g. --integration-path=uiautomation/path/dir). Note that this folder still expects the same directory structure as the one create by `bwoken init`.', :default => 'integration'
     #on :flags=, 'Specify custom build flags (e.g., --flags="-arch=i386,foo=bar")', :as => Array, :default => [] # TODO: implement
     on :formatter=, 'Specify a custom formatter (e.g., --formatter=passthru)', :default => 'colorful'
     on :focus=, 'Specify particular tests to run', :as => Array, :default => []

--- a/lib/bwoken/cli.rb
+++ b/lib/bwoken/cli.rb
@@ -35,6 +35,7 @@ opts = Slop.parse :help => true do
     on :clobber, 'Remove any generated file'
     on :'skip-build', 'Do not build the iOS binary'
     on :verbose, 'Be verbose'
+    on :configuration=, 'The build configruation to use (e.g., --configuration=Release)', :default => 'Debug'
 
     run { ran_command = 'test' }
   end

--- a/lib/bwoken/cli/init.rb
+++ b/lib/bwoken/cli/init.rb
@@ -42,8 +42,9 @@ BANNER
       end
 
       def template filename
+        fixed_filename = "integration" + filename[options[:'integration-path'].length..-1]
         FileUtils.cp \
-          File.expand_path("../templates/#{filename}", __FILE__),
+          File.expand_path("../templates/#{fixed_filename}", __FILE__),
           filename
       end
 

--- a/lib/bwoken/cli/init.rb
+++ b/lib/bwoken/cli/init.rb
@@ -8,7 +8,7 @@ module Bwoken
       class << self
 
         def help_banner
-          <<BANNER
+          <<-BANNER
 Initialize your UIAutomation project.
 
 
@@ -17,20 +17,24 @@ BANNER
         end
       end
 
+      attr_accessor :options
+
       # opts - A slop command object (acts like super-hash)
       #        There are currently no options available
       def initialize opts
-        # opts = opts.to_hash if opts.is_a?(Slop)
+        opts = opts.to_hash if opts.is_a?(Slop)
+        self.options = opts.to_hash
       end
 
       def run
-        directory 'integration/coffeescript/iphone'
-        directory 'integration/coffeescript/ipad'
-        directory 'integration/javascript'
-        directory 'integration/tmp/results'
-        template 'integration/coffeescript/iphone/example.coffee'
-        template 'integration/coffeescript/ipad/example.coffee'
-        template 'integration/javascript/example_vendor.js'
+        integration_dir = options[:'integration-path']
+        directory "#{integration_dir}/coffeescript/iphone"
+        directory "#{integration_dir}/coffeescript/ipad"
+        directory "#{integration_dir}/javascript"
+        directory "#{integration_dir}/tmp/results"
+        template "#{integration_dir}/coffeescript/iphone/example.coffee"
+        template "#{integration_dir}/coffeescript/ipad/example.coffee"
+        template "#{integration_dir}/javascript/example_vendor.js"
       end
 
       def directory dirname

--- a/lib/bwoken/cli/test.rb
+++ b/lib/bwoken/cli/test.rb
@@ -75,6 +75,7 @@ BANNER
           b.formatter = options[:formatter]
           b.scheme = options[:scheme] if options[:scheme]
           b.simulator = options[:simulator]
+          b.configuration = options[:configuration]
         end.compile
       end
 

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -35,12 +35,15 @@ module Bwoken
     end
 
     def cmd
-      "\"#{File.expand_path('../../../bin', __FILE__)}/unix_instruments.sh\" \
+      c = "\"#{File.expand_path('../../../bin', __FILE__)}/unix_instruments.sh\" \
         #{device_flag} \
         -D \"#{self.class.trace_file_path}\" \
         -t \"#{Bwoken.path_to_automation_template}\" \
         \"#{app_dir}\" \
         #{env_variables_for_cli}"
+
+      puts c
+      c
     end
 
     def device_flag

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -25,8 +25,8 @@ module Bwoken
 
     def env_variables
       {
-        'UIASCRIPT' => path,
-        'UIARESULTSPATH' => Bwoken.results_path
+        'UIASCRIPT' => '"' + path + '"',
+        'UIARESULTSPATH' => '"' + Bwoken.results_path + '"'
       }
     end
 
@@ -35,11 +35,11 @@ module Bwoken
     end
 
     def cmd
-      "#{File.expand_path('../../../bin', __FILE__)}/unix_instruments.sh \
+      "\"#{File.expand_path('../../../bin', __FILE__)}/unix_instruments.sh\" \
         #{device_flag} \
-        -D #{self.class.trace_file_path} \
-        -t #{Bwoken.path_to_automation_template} \
-        #{app_dir} \
+        -D \"#{self.class.trace_file_path}\" \
+        -t \"#{Bwoken.path_to_automation_template}\" \
+        \"#{app_dir}\" \
         #{env_variables_for_cli}"
     end
 

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -35,15 +35,12 @@ module Bwoken
     end
 
     def cmd
-      c = "\"#{File.expand_path('../../../bin', __FILE__)}/unix_instruments.sh\" \
+      "\"#{File.expand_path('../../../bin', __FILE__)}/unix_instruments.sh\" \
         #{device_flag} \
         -D \"#{self.class.trace_file_path}\" \
         -t \"#{Bwoken.path_to_automation_template}\" \
         \"#{app_dir}\" \
         #{env_variables_for_cli}"
-
-      puts c
-      c
     end
 
     def device_flag

--- a/lib/bwoken/simulator.rb
+++ b/lib/bwoken/simulator.rb
@@ -11,7 +11,7 @@ module Bwoken
     end
 
     def self.update_device_family_in_plist action, args = nil
-      system_cmd = lambda {|command| Kernel.system "#{plist_buddy} -c '#{command}' #{plist_file}" }
+      system_cmd = lambda {|command| Kernel.system "#{plist_buddy} -c '#{command}' \"#{plist_file}\"" }
 
       case action
       when :delete_array then system_cmd['Delete :UIDeviceFamily']

--- a/lib/bwoken/version.rb
+++ b/lib/bwoken/version.rb
@@ -1,3 +1,3 @@
 module Bwoken
-  VERSION = "2.0.0.beta.1" unless defined?(::Bwoken::VERSION)
+  VERSION = "2.0.0.beta.2" unless defined?(::Bwoken::VERSION)
 end


### PR DESCRIPTION
This PR adds two new configuration options to `bwoken test`:

```
--product-name          Specify a custom product name (e.g. --product-name="My Product"). Default is the name of of the xcodeproj file
--integration-path      Specify a custom directory to store your test scripts in (e.g. --integration-path=uiautomation/path/dir). Note that this folder still expects the same directory structure as the one create by `bwoken init`.
```

One new configuration option is added to `bwoken init`: `--integration-path`.

These options are important for large existing projects where the product name is different than the workspace name and where a folder called `integration` already exists. 

This PR also allows bwoken to work even when there are spaces in the project path.
