### PR TITLE
Make github imports be less restrictive.

### DIFF
--- a/lib/bwoken/coffeescript/github_import_string.rb
+++ b/lib/bwoken/coffeescript/github_import_string.rb
@@ -26,7 +26,7 @@ module Bwoken
       # out to Kernel#`, so we shouldn't be allowing all characters (eg, ';' would be BAD)
       def parse_parts
         importing = @string.match(%r{\A\s*#github\s+['"]?\b([^'"]*)['"]?}i)[1]
-        @repo_name, @file_path = importing.match(%r{([-a-z_0-9]+/[-a-z_0-9]+)/([-a-z_0-9/\.]*)})[1..2]
+        @repo_name, @file_path = importing.match(%r{([-a-z_0-9]+/[-a-z_0-9\.]+)/([-a-z_0-9/\.]*)}i)[1..2]
       end
 
       def ensure_github


### PR DESCRIPTION
Allow the github import command to be case-insensitive and allow periods in repo names.

Example was when I attempted to import:
https://github.com/Marak/Faker.js

The import command was:
# github "Marak/Faker.js/Faker.js"
