### PR TITLE
Allow the ability to specify the SDK version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ $ bwoken test -h
         --focus                 Specify particular tests to run
         --clobber               Remove any generated file
         --skip-build            Do not build the iOS binary
+        --configuration         The build configruation to use (e.g., --configuration=Release)
+        --sdk-version           The SDK version to use (e.g., --sdk=6.1)
         --verbose               Be verbose
     -h, --help                  Display this help message.
 </code></pre>

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ bwoken test -h
         --clobber               Remove any generated file
         --skip-build            Do not build the iOS binary
         --configuration         The build configruation to use (e.g., --configuration=Release)
-        --sdk-version           The SDK version to use (e.g., --sdk=6.1)
+        --sdk-version           The SDK version to use (e.g., --sdk-version=6.1)
         --verbose               Be verbose
     -h, --help                  Display this help message.
 </code></pre>

--- a/lib/bwoken/build.rb
+++ b/lib/bwoken/build.rb
@@ -34,6 +34,7 @@ module Bwoken
     attr_accessor :scheme
     attr_accessor :simulator
     attr_accessor :configuration
+    attr_accessor :sdk_version
     attr_accessor :verbose
 
     def initialize
@@ -67,7 +68,7 @@ module Bwoken
         #{Bwoken.workspace_or_project_flag} \
         #{scheme_string} \
         -configuration #{configuration} \
-        -sdk #{sdk} \
+        -sdk #{sdk}#{sdk_version} \
         -xcconfig #{self.class.xcconfig} \
         #{variables_for_cli} \
         clean build"

--- a/lib/bwoken/cli.rb
+++ b/lib/bwoken/cli.rb
@@ -35,7 +35,7 @@ opts = Slop.parse :help => true do
     on :clobber, 'Remove any generated file'
     on :'skip-build', 'Do not build the iOS binary'
     on :configuration=, 'The build configruation to use (e.g., --configuration=Release)', :default => 'Debug'
-    on :'sdk-version=', 'The SDK version to use (e.g., --sdk=6.1)'
+    on :'sdk-version=', 'The SDK version to use (e.g., --sdk-version=6.1)'
     on :verbose, 'Be verbose'
 
     run { ran_command = 'test' }

--- a/lib/bwoken/cli.rb
+++ b/lib/bwoken/cli.rb
@@ -34,8 +34,9 @@ opts = Slop.parse :help => true do
     on :focus=, 'Specify particular tests to run', :as => Array, :default => []
     on :clobber, 'Remove any generated file'
     on :'skip-build', 'Do not build the iOS binary'
-    on :verbose, 'Be verbose'
     on :configuration=, 'The build configruation to use (e.g., --configuration=Release)', :default => 'Debug'
+    on :'sdk-version=', 'The SDK version to use (e.g., --sdk=6.1)'
+    on :verbose, 'Be verbose'
 
     run { ran_command = 'test' }
   end

--- a/lib/bwoken/cli/test.rb
+++ b/lib/bwoken/cli/test.rb
@@ -50,6 +50,7 @@ BANNER
       #       :integration-path - the base directory for all the integration files
       #       :product-name     - the name of the generated .app file if it is different from the name of the project/workspace
       #       :configuration    - typically "Debug" or "Release"
+      #       :sdk-version      - the version of the sdk to use when building
       def initialize opts
         opts = opts.to_hash if opts.is_a?(Slop)
         self.options = opts.to_hash.tap do |o|
@@ -78,6 +79,7 @@ BANNER
           b.scheme = options[:scheme] if options[:scheme]
           b.simulator = options[:simulator]
           b.configuration = options[:configuration]
+          b.sdk_version = options[:'sdk-version']
         end.compile
       end
 

--- a/spec/lib/bwoken/build_spec.rb
+++ b/spec/lib/bwoken/build_spec.rb
@@ -30,6 +30,7 @@ describe Bwoken::Build do
       scheme_regex = scheme.gsub(/ /, '\s+')
       configuration = stub_out(subject, :configuration, :baz)
       sdk = stub_out(subject, :sdk, :qux)
+      sdk_version = stub_out(subject, :sdk_version, 123)
       xcconfig = stub_out(subject.class, :xcconfig, :quz)
       variables_for_cli = stub_out(subject, :variables_for_cli, :quux)
 
@@ -38,7 +39,7 @@ describe Bwoken::Build do
         #{workspace_regex}\s+
         #{scheme_regex}\s+
         -configuration\s+#{configuration}\s+
-        -sdk\s+#{sdk}\s+
+        -sdk\s+#{sdk}#{sdk_version}\s+
         -xcconfig\s+#{xcconfig}\s+
         #{variables_for_cli}\s+
         clean\s+build


### PR DESCRIPTION
We're still currently building on the 6.1 sdk, so we needed to add this functionality.

This pull request adds the ability to specify the sdk to build with.
