### PR TITLE
Added verbose logger.

### DIFF
--- a/lib/bwoken.rb
+++ b/lib/bwoken.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'logger'
 
 module Bwoken
   class << self
@@ -78,5 +79,18 @@ module Bwoken
       end
     end
 
+    def verbose=(value)
+      @verbose = value
+    end
+
+    def verbose
+      !! @verbose
+    end
+
+    def logger
+      @logger ||= Logger.new(STDOUT).tap do |logger|
+        logger.level = verbose ? Logger::DEBUG : Logger::INFO
+      end
+    end
   end
 end

--- a/lib/bwoken/build.rb
+++ b/lib/bwoken/build.rb
@@ -76,6 +76,8 @@ module Bwoken
     def compile
       formatter.before_build_start
 
+      Bwoken.logger.debug cmd
+
       succeeded, out_string, err_string = RUBY_VERSION == '1.8.7' ? compile_18 : compile_19_plus
 
       if succeeded

--- a/lib/bwoken/cli/test.rb
+++ b/lib/bwoken/cli/test.rb
@@ -61,6 +61,7 @@ BANNER
 
         Bwoken.integration_path = options[:'integration-path']
         Bwoken.app_name = options[:'product-name']
+        Bwoken.verbose = options[:'verbose']
       end
 
       def run

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -50,6 +50,8 @@ module Bwoken
     def run
       formatter.before_script_run path
 
+      Bwoken.logger.debug cmd
+
       Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
         exit_status = formatter.format stdout
         raise ScriptFailedError.new('Test Script Failed') unless exit_status == 0

--- a/spec/lib/bwoken/script_spec.rb
+++ b/spec/lib/bwoken/script_spec.rb
@@ -33,6 +33,13 @@ describe Bwoken::Script do
       subject.run
     end
 
+    it 'logs the command being run' do
+      subject.stub(:cmd).and_return('cmd')
+      Open3.stub(:popen3)
+      Bwoken.logger.should_receive(:debug).with('cmd')
+      subject.run
+    end
+
     context 'when passing' do
       it 'does not raise a ScriptFailedError' do
         Open3.stub(:popen3).and_yield(*%w(in out err thr))


### PR DESCRIPTION
Between two machines `unix_instruments` hung in two different ways (one with `/dev/ttyvf` being busy, another without an error). The first one cleared after a reboot, working on the other one. In either case bwoken gave no indication of what's going on.

This PR adds a logger that you can call from anywhere, for now it just logs the commands being run, so one of my outputs is stuck with this, at least this is something one can rerun manually to figure out where the issue is.

```
D, [2013-12-19T18:07:47.706289 #4615] DEBUG -- : "/Users/dblock/.rvm/gems/ruby-2.0.0-p353/bundler/gems/bwoken-e7d6ffbe5005/bin/unix_instruments.sh"                  -D "/Users/dblock/source/artsy-ios-foo/dblock/integration/tmp/trace"         -t "/Applications/Xcode.app/Contents/Applications/Instruments.app/Contents/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate"         "/Users/dblock/source/artsy-ios-foo/dblock/build/iphonesimulator/Foo.app"         -e UIASCRIPT "/Users/dblock/source/artsy-ios-foo/dblock/integration/tmp/javascript/iphone/test_shows_list.js" -e UIARESULTSPATH "/Users/dblock/source/artsy-ios-foo/dblock/integration/tmp/results"
```
