### PR TITLE
Explicitly check whether /dev/ptyvf is busy or not.

### DIFF
--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -47,8 +47,21 @@ module Bwoken
       simulator ? '' : "-w #{Bwoken::Device.uuid}"
     end
 
+    # unix_instruments will try to open /dev/ptyvf
+    def check_ptyvf!
+      ptyvf_fd = IO.sysopen('/dev/ptyvf', 'r')
+      ptyvf_io = IO.new(ptyvf_fd, 'r')
+    rescue Errno::EBUSY => e
+      # TODO: log error here
+      raise
+    ensure
+      ptyvf_io.close if ptyvf_io
+    end
+
     def run
       formatter.before_script_run path
+
+      check_ptyvf!
 
       Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
         exit_status = formatter.format stdout

--- a/spec/lib/bwoken/script_spec.rb
+++ b/spec/lib/bwoken/script_spec.rb
@@ -15,6 +15,7 @@ describe Bwoken::Script do
   describe '#run' do
     let(:exit_status) { 0 }
     before do
+      IO.stub(:sysopen).and_return(STDOUT.fcntl(Fcntl::F_DUPFD))
       subject.formatter.stub(:format).and_return(exit_status)
       subject.formatter.stub(:before_script_run)
     end
@@ -129,6 +130,14 @@ describe Bwoken::Script do
       let(:expected_device_flag_regexp) { '' }
 
       its(:cmd) { should match regexp }
+    end
+  end
+
+  describe "#check_ptyvf!" do
+    it "raises an exception when busy" do
+      subject.formatter.stub(:before_script_run)
+      IO.should_receive(:sysopen).with('/dev/ptyvf', 'r').and_raise('busy!')
+      expect { subject.run }.to raise_error RuntimeError, "busy!"
     end
   end
 


### PR DESCRIPTION
This helps with #56, explicitly checking whether `/dev/ptyvf` is in use. It would be nice to modify `unix_instruments` to detect that, but I couldn't figure out for the life of me how to do that _and_ collect output with `tee`.
