### PR TITLE
Added the ability to retry failing tests

### DIFF
--- a/lib/bwoken/cli.rb
+++ b/lib/bwoken/cli.rb
@@ -37,6 +37,7 @@ opts = Slop.parse :help => true do
     on :configuration=, 'The build configruation to use (e.g., --configuration=Release)', :default => 'Debug'
     on :'sdk-version=', 'The SDK version to use (e.g., --sdk-version=6.1)'
     on :verbose, 'Be verbose'
+    on :retry=, 'Specify number of times to retry a failing test (e.g., --retry=1)', :default => 0
 
     run { ran_command = 'test' }
   end

--- a/lib/bwoken/cli/test.rb
+++ b/lib/bwoken/cli/test.rb
@@ -51,6 +51,7 @@ BANNER
       #       :product-name     - the name of the generated .app file if it is different from the name of the project/workspace
       #       :configuration    - typically "Debug" or "Release"
       #       :sdk-version      - the version of the sdk to use when building
+      #       :retry            - number of times a failed test will retry
       def initialize opts
         opts = opts.to_hash if opts.is_a?(Slop)
         self.options = opts.to_hash.tap do |o|
@@ -58,6 +59,7 @@ BANNER
           o[:formatter] = select_formatter(o[:formatter])
           o[:simulator] = use_simulator?(o[:simulator])
           o[:family] = o[:family]
+          o[:retry] = o[:retry].to_i
         end
 
         Bwoken.integration_path = options[:'integration-path']
@@ -110,6 +112,7 @@ BANNER
           s.focus = options[:focus]
           s.formatter = options[:formatter]
           s.simulator = options[:simulator]
+          s.retries = options[:retry]
         end.execute
       end
 

--- a/lib/bwoken/device_runner.rb
+++ b/lib/bwoken/device_runner.rb
@@ -6,6 +6,7 @@ module Bwoken
     attr_accessor :focus
     attr_accessor :formatter
     attr_accessor :app_dir
+    attr_accessor :retries
 
     alias_method :feature_names, :focus
 
@@ -28,6 +29,7 @@ module Bwoken
           s.device_family = device_family
           s.formatter = formatter
           s.app_dir = app_dir
+          s.retries = retries
         end
       end
     end

--- a/lib/bwoken/script_runner.rb
+++ b/lib/bwoken/script_runner.rb
@@ -8,6 +8,7 @@ module Bwoken
     attr_accessor :formatter
     attr_accessor :simulator
     attr_accessor :app_dir
+    attr_accessor :retries
 
     alias_method :feature_names, :focus
 
@@ -40,6 +41,7 @@ module Bwoken
         sr.formatter = formatter
         sr.simulator = simulator
         sr.app_dir = app_dir
+        sr.retries = retries
       end
     end
 
@@ -60,6 +62,7 @@ module Bwoken
         dr.focus = focus
         dr.formatter = formatter
         dr.app_dir = app_dir
+        dr.retries = retries
       end
     end
 

--- a/lib/bwoken/simulator_runner.rb
+++ b/lib/bwoken/simulator_runner.rb
@@ -9,6 +9,7 @@ module Bwoken
     attr_accessor :simulator
     attr_accessor :app_dir
     attr_accessor :device_family
+    attr_accessor :retries
 
     alias_method :feature_names, :focus
 
@@ -29,6 +30,7 @@ module Bwoken
           s.formatter = formatter
           s.simulator = simulator
           s.app_dir = app_dir
+          s.retries = retries
         end
       end
     end

--- a/spec/lib/bwoken/script_spec.rb
+++ b/spec/lib/bwoken/script_spec.rb
@@ -17,6 +17,7 @@ describe Bwoken::Script do
     before do
       subject.formatter.stub(:format).and_return(exit_status)
       subject.formatter.stub(:before_script_run)
+      subject.retries = 0
     end
 
     it 'outputs that a script is about to run' do
@@ -49,6 +50,15 @@ describe Bwoken::Script do
         subject.stub(:cmd)
         expect { subject.run }.to raise_error(Bwoken::ScriptFailedError)
       end
+
+      it 'will retry a failing test' do
+        subject.retries = 2
+        subject.should_receive(:run_with_retries).exactly(3).times.and_call_original
+        Open3.stub(:popen3).and_yield(*%w(in out err thr))
+        subject.stub(:cmd)
+        expect { subject.run }.to raise_error(Bwoken::ScriptFailedError)
+      end
+
     end
 
     it 'formats the output with the bwoken formatter' do


### PR DESCRIPTION
Let me explain my reasoning behind this feature.  I have many tests, some of them rather long.  They talk to a backend server (I have another modification to the code I have not made a PR for that lets me call a script after each test run to clear my server database).  I do not want to mock out server calls because I want true end to end tests.

Given the above sometimes tests are going to fail because the server took a very long time to respond.  I want to be able to run the tests, go get coffee, come back and see if my tests failed or passed.

Right now I very often find myself needing to run focus tests on a lot of tests because something along the lines failed because of server lag.

Between this and the run all tests pull request I can be confident that when I return to my computer I will know the status of my tests (although I will need to spend a little extra time parsing the output to be sure).
