### PR TITLE
Specify the device to be used by Instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Here's a list of all the switches that bwoken takes for the `test` command:
 $ bwoken test -h
 [...]
         --simulator             Use simulator, even when an iDevice is connected
+        --device                Use given device (name or id)
         --family                Test only one device type, either ipad or iphone. Default is to test on both
         --scheme                Specify a custom scheme
         --product-name          Specify a custom product name (e.g. --product-name="My Product"). Default is the name of of the xcodeproj file

--- a/lib/bwoken/cli.rb
+++ b/lib/bwoken/cli.rb
@@ -23,6 +23,7 @@ opts = Slop.parse :help => true do
     banner Bwoken::CLI::Test.help_banner
 
     on :simulator, 'Use simulator, even when an iDevice is connected', :default => false
+    on :device=, 'Use given device (name or id)', :default => nil
 
     on :family=, 'Test only one device type, either ipad or iphone. Default is to test on both',
       :match => /\A(?:ipad|iphone|all)\Z/i, :default => 'all'

--- a/lib/bwoken/cli/test.rb
+++ b/lib/bwoken/cli/test.rb
@@ -110,6 +110,7 @@ BANNER
           s.focus = options[:focus]
           s.formatter = options[:formatter]
           s.simulator = options[:simulator]
+          s.device = options[:device]
         end.execute
       end
 

--- a/lib/bwoken/device_runner.rb
+++ b/lib/bwoken/device_runner.rb
@@ -6,6 +6,7 @@ module Bwoken
     attr_accessor :focus
     attr_accessor :formatter
     attr_accessor :app_dir
+    attr_accessor :device
 
     alias_method :feature_names, :focus
 
@@ -28,6 +29,7 @@ module Bwoken
           s.device_family = device_family
           s.formatter = formatter
           s.app_dir = app_dir
+          s.device = device
         end
       end
     end

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -17,6 +17,7 @@ module Bwoken
     attr_accessor :device_family
     attr_accessor :formatter
     attr_accessor :simulator
+    attr_accessor :device
     attr_accessor :app_dir
 
     def initialize
@@ -44,6 +45,10 @@ module Bwoken
     end
 
     def device_flag
+      if !device.nil?
+        return "-w '#{device}'"
+      end
+      
       simulator ? '' : "-w #{Bwoken::Device.uuid}"
     end
 

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -46,7 +46,7 @@ module Bwoken
 
     def device_flag
       if !device.nil?
-        return "-w '#{device}'"
+        return "-w \"#{device}\""
       end
       
       simulator ? '' : "-w #{Bwoken::Device.uuid}"

--- a/lib/bwoken/script_runner.rb
+++ b/lib/bwoken/script_runner.rb
@@ -7,6 +7,7 @@ module Bwoken
     attr_accessor :focus
     attr_accessor :formatter
     attr_accessor :simulator
+    attr_accessor :device
     attr_accessor :app_dir
 
     alias_method :feature_names, :focus
@@ -39,6 +40,7 @@ module Bwoken
         sr.focus = focus
         sr.formatter = formatter
         sr.simulator = simulator
+        sr.device = device
         sr.app_dir = app_dir
       end
     end
@@ -60,6 +62,7 @@ module Bwoken
         dr.focus = focus
         dr.formatter = formatter
         dr.app_dir = app_dir
+        dr.device = device
       end
     end
 

--- a/lib/bwoken/simulator_runner.rb
+++ b/lib/bwoken/simulator_runner.rb
@@ -7,6 +7,7 @@ module Bwoken
     attr_accessor :focus
     attr_accessor :formatter
     attr_accessor :simulator
+    attr_accessor :device
     attr_accessor :app_dir
     attr_accessor :device_family
 
@@ -28,6 +29,7 @@ module Bwoken
           s.device_family = device_family
           s.formatter = formatter
           s.simulator = simulator
+          s.device = device
           s.app_dir = app_dir
         end
       end


### PR DESCRIPTION
Specify explicitly which device should be used when invoking `instruments`. Supports both name or UUID of the device, as listed by `instruments -s devices`.

This helped me avoid the issue #76 and could help also with #77.
