### PR TITLE
Universal folder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bwoken (2.1.0.rc.2)
+    bwoken (2.1.0.rc.3)
       coffee-script-source
       colorful
       execjs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bwoken (2.1.0.rc.3)
+    bwoken (2.1.0.rc.2)
       coffee-script-source
       colorful
       execjs

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To add new coffeescript test, add those file to the /integration/coffeescript/ip
 To add new javascript test, if the iphone and ipad folder don't exist in the /integration/javascript forlder, create them. 
 Then copy your test file inside those folder depending on your target.
 Your file hierarchy should look something like this
+
 <pre><code>
 | integration
 	| coffeescript
@@ -34,11 +35,13 @@ Your file hierarchy should look something like this
 			| exemple.coffee
 		| ipad
 			| example.coffee
+    | universal
 	| javascript
 		| iphone
 			| myTest.js
 		| ipad
 			| myiPadtest.js
+    | universal
 	|tmp
 </code></pre>
 

--- a/lib/bwoken/cli/init.rb
+++ b/lib/bwoken/cli/init.rb
@@ -28,7 +28,10 @@ BANNER
       def run
         directory "coffeescript/iphone"
         directory "coffeescript/ipad"
-        directory "javascript"
+        directory "coffeescript/universal"
+        directory "javascript/iphone"
+        directory "javascript/ipad"
+        directory "javascript/universal"
         directory "tmp/results"
         template "coffeescript/iphone/example.coffee"
         template "coffeescript/ipad/example.coffee"

--- a/lib/bwoken/device_runner.rb
+++ b/lib/bwoken/device_runner.rb
@@ -45,6 +45,7 @@ module Bwoken
     def test_files_from_feature_names
       feature_names.map do |feature_name|
         File.join(Bwoken.test_suite_path, device_family, "#{feature_name}.js")
+        # TODO: Also join in universal
       end
     end
 
@@ -53,11 +54,13 @@ module Bwoken
     end
 
     def all_files_in_test_dir
-      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/*.js"]
+      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/*.js"] +
+      Dir["#{Bwoken.test_suite_path}/universal/**/*.js"]
     end
 
     def helper_files
-      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/helpers/**/*.js"]
+      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/helpers/**/*.js"] +
+      Dir["#{Bwoken.test_suite_path}/universal/**/helpers/**/*.js"]
     end
 
   end

--- a/lib/bwoken/device_runner.rb
+++ b/lib/bwoken/device_runner.rb
@@ -43,9 +43,10 @@ module Bwoken
     end
 
     def test_files_from_feature_names
-      feature_names.map do |feature_name|
-        File.join(Bwoken.test_suite_path, device_family, "#{feature_name}.js")
-        # TODO: Also join in universal
+      all_test_files.select do |file_name|
+        feature_names.any? do |feature_name|
+          file_name.include?(feature_name)
+        end
       end
     end
 

--- a/lib/bwoken/script.rb
+++ b/lib/bwoken/script.rb
@@ -48,7 +48,7 @@ module Bwoken
       if !device.nil?
         return "-w \"#{device}\""
       end
-      
+
       simulator ? '' : "-w #{Bwoken::Device.uuid}"
     end
 

--- a/lib/bwoken/simulator_runner.rb
+++ b/lib/bwoken/simulator_runner.rb
@@ -44,8 +44,10 @@ module Bwoken
     end
 
     def test_files_from_feature_names
-      feature_names.map do |feature_name|
-        File.join(Bwoken.test_suite_path, device_family, "#{feature_name}.js")
+      all_test_files.select do |file_name|
+        feature_names.any? do |feature_name|
+          file_name.include?(feature_name)
+        end
       end
     end
 

--- a/lib/bwoken/simulator_runner.rb
+++ b/lib/bwoken/simulator_runner.rb
@@ -54,11 +54,13 @@ module Bwoken
     end
 
     def all_files_in_test_dir
-      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/*.js"]
+      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/*.js"] +
+      Dir["#{Bwoken.test_suite_path}/universal/**/*.js"]
     end
 
     def helper_files
-      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/helpers/**/*.js"]
+      Dir["#{Bwoken.test_suite_path}/#{device_family}/**/helpers/**/*.js"] +
+      Dir["#{Bwoken.test_suite_path}/universal/**/helpers/**/*.js"]
     end
 
   end


### PR DESCRIPTION
The folder will be created on `init` and it should run through any tests in the universal folder regardless of device family.

Fixes #59

I haven't been able to 100% test it due to #83. I've got a small [project](https://github.com/ryanjm/BwokenTestApp) to test it with. The initialization process of creating the universal folder worked as expected.
