### PR TITLE
Freeze slop dependency to 3.6

### DIFF
--- a/bwoken.gemspec
+++ b/bwoken.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'execjs'
   gem.add_dependency 'json_pure'
   gem.add_dependency 'rake'
-  gem.add_dependency 'slop'
+  gem.add_dependency 'slop', '~> 3.6'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'guard-rspec'


### PR DESCRIPTION
As Bwoken doesn't work with slop 4

Cf. Issue #90 
